### PR TITLE
make sure only single backslashes get replaced

### DIFF
--- a/after/syntax/haskell.vim
+++ b/after/syntax/haskell.vim
@@ -33,7 +33,7 @@ if exists('g:no_haskell_conceal') || !has('conceal') || &enc != 'utf-8'
 endif
 
 " vim: set fenc=utf-8:
-syntax match hsNiceOperator "\\" conceal cchar=λ
+syntax match hsNiceOperator "\\\@<!\\\\\@!=" conceal cchar=λ
 syntax match hsNiceOperator "<-" conceal cchar=←
 syntax match hsNiceOperator "->" conceal cchar=→
 syntax match hsNiceOperator "\<sum\>" conceal cchar=∑


### PR DESCRIPTION
modified the regex so that the \\ operator (list difference) from Data.List
does not get replaced by λλ.
