### PR TITLE
Fix casing of hsNiceOperator

### DIFF
--- a/after/syntax/haskell.vim
+++ b/after/syntax/haskell.vim
@@ -77,7 +77,7 @@ if s:extraConceal
     syntax match hs_DeclareFunction /^[a-z_(]\S*\(\s\|\n\)*::/me=e-2 nextgroup=hsNiceOperator contains=hs_FunctionName,hs_OpFunctionName
     syntax match hsNiceOperator "\:\:" conceal cchar=∷
 
-    syntax match hsniceoperator "++" conceal cchar=⧺
+    syntax match hsNiceoperator "++" conceal cchar=⧺
     syntax match hsNiceOperator "\<forall\>" conceal cchar=∀
     syntax match hsNiceOperator "-<" conceal cchar=↢
     syntax match hsNiceOperator ">-" conceal cchar=↣


### PR DESCRIPTION
Just a small typo, I don't know if this affects anything, but it seam odd that in just one place the n in hsNiceOperator was lower case.
